### PR TITLE
修改-获取手机号逻辑

### DIFF
--- a/src/Translator/UserTranslator.php
+++ b/src/Translator/UserTranslator.php
@@ -25,9 +25,9 @@ class UserTranslator
         }
         $user->name = $info['name'];
         $user->position = $info['position'];
-        $user->mobile = $info['mobile'] ?? '';
+        $user->mobile = $info['extattr']['attrs'][0]['value'] ?? '';
         $user->email = $info['biz_mail'] ?? $info['email'] ?? '';
-        $user->avatar = $info['thumb_avatar'] ?? $info['avatar'] ?? '';
+        $user->avatar = '';
         $user->status = $info['status'];
         $user->enable = $info['enable'];
         $user->alias = $info['alias'];

--- a/tests/Cases/AbstractTestCase.php
+++ b/tests/Cases/AbstractTestCase.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace HyperfTest\Cases;
 
 use Hyperf\Contract\ConfigInterface;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 
 use function KY\WorkWxUser\di;
@@ -24,7 +23,7 @@ abstract class AbstractTestCase extends TestCase
 {
     protected function tearDown(): void
     {
-        Mockery::close();
+        \Mockery::close();
     }
 
     /**

--- a/tests/Stub/ContainerStub.php
+++ b/tests/Stub/ContainerStub.php
@@ -24,7 +24,6 @@ use Hyperf\HttpServer\Contract\RequestInterface;
 use Hyperf\Utils\ApplicationContext;
 use Hyperf\Utils\Codec\Json;
 use KY\WorkWxUser\WeChat\WeChatFactory;
-use Mockery;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\NullLogger;
@@ -35,7 +34,7 @@ class ContainerStub
 {
     public static function mockContainer(): ContainerInterface
     {
-        $container = Mockery::mock(ContainerInterface::class);
+        $container = \Mockery::mock(ContainerInterface::class);
         $container->shouldReceive('get')->with(ConfigInterface::class)->andReturnUsing(function () {
             $file = BASE_PATH . '/.env.json';
             if (file_exists($file)) {
@@ -64,10 +63,10 @@ class ContainerStub
             if ($isMockery) {
                 $config = $container->get(ConfigInterface::class)->get('work_wx_user');
                 $application = new Application($config);
-                $application->setHttpClient($client = Mockery::mock(HttpClientInterface::class));
+                $application->setHttpClient($client = \Mockery::mock(HttpClientInterface::class));
                 $client->shouldReceive('request')->withAnyArgs()->andReturnUsing(function (string $method, string $url, array $options) {
                     $path = __DIR__ . '/json/' . $method . str_replace('/', '_', $url) . '.json';
-                    $response = Mockery::mock(ResponseInterface::class);
+                    $response = \Mockery::mock(ResponseInterface::class);
                     $response->shouldReceive('toArray')->andReturn(
                         Json::decode(file_get_contents($path))
                     );


### PR DESCRIPTION
[企业微信：从2022年6月20号20点开始不再返回：头像、性别、手机等敏感信息](https://developer.work.weixin.qq.com/document/path/90196#15232)